### PR TITLE
BC-27536: Relay state, and assorted other fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN chown -R app_user:app_user ${APP_DIR}
 USER app_user
 
 FROM ruby:3.1.2-alpine
-RUN apk add --no-cache sqlite-dev
+RUN apk add --no-cache sqlite-dev gcompat
 RUN mkdir /app
 WORKDIR /app
 COPY --from=builder /app/public/ ./public

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://user-images.githubusercontent.com/783501/168935031-caab559e-7b5d-4056-96
 #### Docker
 
  1. `docker build . -t saml-ruby-idp`
- 2. `docker run --rm -p9292:9292 samp-ruby-idp`
+ 2. `docker run --rm -p9567:9292 saml-ruby-idp`
 
 #### Ruby
 

--- a/app.rb
+++ b/app.rb
@@ -56,7 +56,7 @@ class MockSamlIdpApp < Sinatra::Base
   post '/saml-login' do
     decode_request(params[:SAMLRequest])
 
-    @saml_response = encode_response(fake_user)
+    @saml_response = encode_response(fake_user, signed_message: true)
 
     haml :saml_post
   end

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
-import { getSamlRequest } from "../utils";
+import { getSamlRequest, getRelayState } from "../utils";
 import { Ce, UserCircle } from "tabler-icons-react";
 interface LoginFormProps {
   username?: string;
@@ -31,6 +31,7 @@ const LoginForm: React.FunctionComponent<LoginFormProps> = ({ username }) => {
         onSubmit={() => submitting()}
       >
         <input type="hidden" name="SAMLRequest" value={getSamlRequest()} />
+        <input type="hidden" name="RelayState" value={getRelayState()} />
         <Center>
           <Title order={1}>SAML Mock Identity Provider</Title>
         </Center>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -21,3 +21,10 @@ export const getSamlRequest = (): string => {
 
   return urlParams.get('SAMLRequest') ?? ''
 }
+
+export const getRelayState = (): string => {
+  const queryString = window.location.search
+  const urlParams = new URLSearchParams(queryString)
+
+  return urlParams.get('RelayState') ?? ''
+}

--- a/views/saml_post.haml
+++ b/views/saml_post.haml
@@ -7,5 +7,5 @@
   %body{onload: "document.forms[0].submit();", style: "visibility:hidden;"}
     %form{action: saml_acs_url, method: "post"}
       %input{type: "hidden", name: "SAMLResponse", value: @saml_response}
-      %input{type: "hidden", name: "RelayState", value: @relay_state}
+      %input{type: "hidden", name: "RelayState", value: params[:RelayState]}
       %input{type: "submit", value: "Submit"}


### PR DESCRIPTION
Pass the RelayState from the request all the way to the response (required because we're going to use relaystate to correlate saml login requests to responses in hodor)

Sign saml responses to better match what production IdP instances will be doing

Add `gcompat` apk package in dockerfile to fix builds when running on ARM macs (see https://stackoverflow.com/questions/70963924/unable-to-load-nokogiri-in-docker-container-on-m1-mac)