### PR TITLE
Bc 27536 minor adjustment to docker files to fix local builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.1.2-alpine AS builder
-RUN apk add --no-cache nodejs npm bash curl musl-dev libc-dev make gcc sqlite-dev
+RUN apk add --no-cache nodejs npm bash curl musl-dev libc-dev make gcc sqlite-dev gcompat
 ENV APP_DIR=/app
 
 RUN mkdir ${APP_DIR}


### PR DESCRIPTION
gcompat is required on the `builder` dockerfile for the build to produce an artifact that can serve requests (I had it working initially, but removed it because removing it didn't seem to stop the built docker image from starting, unfortunately, when I went back to testing my feature I found that it started just fine, but didn't respond to requests)